### PR TITLE
chore: MEC-1408 Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @rusticpenguin
+* @contentful/team-devrel


### PR DESCRIPTION
Since the codeowner doesn't have access to the repo, I thought it's best to put the @contentful/team-devrel team as owners as per the access